### PR TITLE
Use GITHUB_OUTPUT instead of deprecated set-output

### DIFF
--- a/.github/workflows/pre-submit-glibc.yaml
+++ b/.github/workflows/pre-submit-glibc.yaml
@@ -20,7 +20,7 @@ jobs:
     - name: Generate snapshot date
       id: snapshot-date
       run: |
-        echo ::set-output name=date::$(date -u +%Y%m%d)
+        echo "date=$(date -u +%Y%m%d)" >> $GITHUB_OUTPUT
       shell: bash
 
     - uses: chainguard-images/actions/apko-build@main

--- a/.github/workflows/pre-submit.yaml
+++ b/.github/workflows/pre-submit.yaml
@@ -21,7 +21,7 @@ jobs:
     - name: Generate snapshot date
       id: snapshot-date
       run: |
-        echo ::set-output name=date::$(date -u +%Y%m%d)
+        echo "date=$(date -u +%Y%m%d)" >> $GITHUB_OUTPUT
       shell: bash
 
     - uses: chainguard-images/actions/apko-build@main

--- a/.github/workflows/release-glibc.yaml
+++ b/.github/workflows/release-glibc.yaml
@@ -50,7 +50,7 @@ jobs:
       id: emit-refs
       run: |
         cat apko.images | sed 's/$/\n/g' | grep -v '^$' | jq -R -s -c 'split("\n")[:-1]' | jq .
-        echo ::set-output name=image-refs::$(cat apko.images | sed 's/$/\n/g' | grep -v '^$' | jq -R -s -c 'split("\n")[:-1]')
+        echo "image-refs=$(cat apko.images | sed 's/$/\n/g' | grep -v '^$' | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
 
     # Post to slack when things fail.
     - if: ${{ failure() }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,7 +48,7 @@ jobs:
       id: emit-refs
       run: |
         cat apko.images | sed 's/$/\n/g' | grep -v '^$' | jq -R -s -c 'split("\n")[:-1]' | jq .
-        echo ::set-output name=image-refs::$(cat apko.images | sed 's/$/\n/g' | grep -v '^$' | jq -R -s -c 'split("\n")[:-1]')
+        echo "image-refs=$(cat apko.images | sed 's/$/\n/g' | grep -v '^$' | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
 
     # Post to slack when things fail.
     - if: ${{ failure() }}


### PR DESCRIPTION

#### Summary
- Use GITHUB_OUTPUT instead of deprecated set-output

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/